### PR TITLE
Update buildpack

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,7 +3,7 @@ applications:
 - name: project_resource_search-((env))
   buildpacks:
     - nodejs_buildpack
-    - ruby_buildpack
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.50
   env:
     RAILS_MASTER_KEY: ((rails_master_key))
     RAILS_ENV: production


### PR DESCRIPTION
1.8.50 avoids the gem installation issues we saw with the cloud.gov-supplied 1.8.49